### PR TITLE
do not warn about overridden notation

### DIFF
--- a/code/_CoqProject
+++ b/code/_CoqProject
@@ -3,6 +3,7 @@ COQDEP = coqdep
 -R . "GrpdHITs"
 
 -arg "-type-in-type"
+-arg "-w -notation-overridden"
 
 prelude/basics.v
 prelude/grpd_bicat.v


### PR DESCRIPTION
The number of warnings is enormous and makes it impossible to track other output from compilation.