### PR TITLE
Fix GrpdHITs

### DIFF
--- a/code/hit_biadjunction/gquot_commute.v
+++ b/code/hit_biadjunction/gquot_commute.v
@@ -601,7 +601,7 @@ Definition poly_gquot_isweq
            (X : groupoid)
   : isweq (poly_gquot P X).
 Proof.
-  use gradth.
+  use isweq_iso.
   - exact (@gquot_poly P X).
   - exact (gquot_poly_poly_gquot_eq P).
   - exact (poly_gquot_gquot_poly_eq P).

--- a/code/hit_biadjunction/hit_prealgebra_biadj/left_triangle.v
+++ b/code/hit_biadjunction/hit_prealgebra_biadj/left_triangle.v
@@ -79,14 +79,15 @@ Proof.
                    (!(maponpaths
                         (maponpaths _)
                         (gquot_rec_beta_gcleq _ _ _ _ _ _ _ _ _ _)
-                      @ gquot_rec_beta_gcleq _ _ _ _ _ _ _ _ _ _)
-                    @ maponpathscomp
-                        (gquot_functor_map (gquot_unit G))
-                        (gquot_counit_map _)
-                        (gcleq G g))
+                      @ _)
+                      @ maponpathscomp
+                          (gquot_functor_map (gquot_unit G))
+                          (gquot_counit_map _)
+                          (gcleq G g))
                    (!(maponpathsidfun _))
                    (idpath _)
-                   (vrefl _))).
+                   (vrefl _)) ;
+         apply gquot_rec_beta_gcleq).
     + exact (λ _, gtrunc _ _ _).
   - induction z as [z | z].
     + exact (maponpaths inl (IHP₁ z)).
@@ -643,34 +644,35 @@ Proof.
     + intro.
       apply idpath.
     + abstract
-     (intros a₁ a₂ g ;
-      apply map_PathOver ;
-      refine (whisker_square
-                (idpath _)
-                (!(maponpaths
-                     (maponpaths _)
-                     _
-                   @ _)
-                 @ maponpathscomp _ _ _)
-                (!(maponpaths
-                     (maponpaths _)
-                     (_ @ _))
-                 @ maponpathscomp _ _ _)
-                (idpath _)
-                _) ;
-      [ exact (gquot_rec_beta_gcleq G _ _ _ _ _ _ _ _ g)
-      | exact (gquot_rec_beta_gcleq
-                 (poly_act_groupoid I G)
-                 _ _ _ _ _ _ _ _ g)
-      | exact (!(maponpathscomp (gquot_functor_map _) (gquot_counit_map _) _))
-      | exact (maponpaths
-                 (maponpaths _)
-                 (gquot_rec_beta_gcleq _ _ _ _ _ _ _ _ _ _)
-               @ gquot_rec_beta_gcleq _ _ _ _ _ _ _ _ _ _)
-      | refine (pathscomp0rid _ @ _) ;
-        simpl ;
-        induction (gcleq G g) ;
-        exact (ge _ _) ]).
+        (intros a₁ a₂ g ;
+         apply map_PathOver ;
+         refine (whisker_square
+                   (idpath _)
+                   (!(maponpaths
+                        (maponpaths _)
+                        _
+                        @ _)
+                      @ maponpathscomp _ _ _)
+                   (!(maponpaths
+                        (maponpaths _)
+                        (_ @ _))
+                      @ maponpathscomp _ _ _)
+                   (idpath _)
+                   _) ;
+         [ exact (gquot_rec_beta_gcleq G _ _ _ _ _ _ _ _ g)
+         | exact (gquot_rec_beta_gcleq
+                    (poly_act_groupoid I G)
+                    _ _ _ _ _ _ _ _ g)
+         | exact (!(maponpathscomp (gquot_functor_map _) (gquot_counit_map _) _))
+         | refine (maponpaths
+                  (maponpaths _)
+                  (gquot_rec_beta_gcleq _ _ _ _ _ _ _ _ _ _)
+                @ _) ;
+           apply gquot_rec_beta_gcleq
+         | refine (pathscomp0rid _ @ _) ;
+           simpl ;
+           induction (gcleq G g) ;
+           exact (ge _ _) ]).
     + exact (λ _, gtrunc _ _ _).
   - induction z as [z | z].
     + refine (_ @ maponpaths gquot_inl_grpd (IHP₁ z)).

--- a/code/initial_grpd_alg/W_poly.v
+++ b/code/initial_grpd_alg/W_poly.v
@@ -255,7 +255,7 @@ Definition interpret_constant_weq
 Proof.
   use make_weq.
   - exact (interpret_constant A X).
-  - use gradth.
+  - use isweq_iso.
     + exact (to_interpret_constant A X).
     + intros x.
       use total2_paths_f.
@@ -283,7 +283,7 @@ Definition interpret_identity_weq
 Proof.
   use make_weq.
   - exact (interpret_identity X).
-  - use gradth.
+  - use isweq_iso.
     + exact (to_interpret_identity X).
     + intros x.
       induction x as [sx px].
@@ -334,7 +334,7 @@ Definition interpret_sum_weq
 Proof.
   use make_weq.
   - exact (interpret_sum C₁ C₂ X).
-  - use gradth.
+  - use isweq_iso.
     + exact (to_interpret_sum C₁ C₂ X).
     + intro z.
       induction z as [sz pz].
@@ -378,7 +378,7 @@ Definition interpret_prod_weq
 Proof.
   use make_weq.
   - exact (interpret_prod C₁ C₂ X).
-  - use gradth.
+  - use isweq_iso.
     + exact (to_interpret_prod C₁ C₂ X).
     + intro z.
       use total2_paths_f.
@@ -534,7 +534,7 @@ Definition interpret_poly_weq
 Proof.
   use make_weq.
   - exact (interpret_poly P X).
-  - use gradth.
+  - use isweq_iso.
     + exact (to_interpret_poly P X).
     + exact (to_interpret_poly_interpret_poly' P X).
     + exact (interpret_poly_to_interpret_poly P X).

--- a/code/prelude/cubical_methods.v
+++ b/code/prelude/cubical_methods.v
@@ -33,7 +33,7 @@ Definition PathOver_to_path_isweq
            (c₁ : C a₁) (c₂ : C a₂)
   : isweq (@PathOver_to_path A C a₁ a₂ p c₁ c₂).
 Proof.
-  use gradth.
+  use isweq_iso.
   - exact path_to_PathOver.
   - intros q.
     induction p.
@@ -75,7 +75,7 @@ Section operations.
          {c₁ c₂ : C}
     : isweq (@PathOver_const A C a₁ a₂ p c₁ c₂).
   Proof.
-    use gradth.
+    use isweq_iso.
     - exact (PathOverConstant_map1 p).
     - intros q.
       induction p.
@@ -114,7 +114,7 @@ Section operations.
          {c₁ : C (f a₁)} {c₂ : C (f a₂)}
     : isweq (@PathOver_compose A B C f a₁ a₂ p c₁ c₂).
   Proof.
-    use gradth.
+    use isweq_iso.
     - exact (compose_PathOver f).
     - intros q.
       induction p.

--- a/code/prelude/groupoid_quotient/gquot_encode_decode.v
+++ b/code/prelude/groupoid_quotient/gquot_encode_decode.v
@@ -41,7 +41,7 @@ Section encode_decode.
              (g : b₁ --> b₂)
     : isweq (right_action a g).
   Proof.
-    use gradth.
+    use isweq_iso.
     - exact (right_action_inv a g).
     - abstract
         (intros h ; cbn ;
@@ -74,7 +74,7 @@ Section encode_decode.
              (g : b₁ --> b₂)
     : isweq (left_action a g).
   Proof.
-    use gradth.
+    use isweq_iso.
     - exact (left_action_inv a g).
     - abstract
         (intros h ; cbn ;
@@ -313,7 +313,7 @@ Section encode_decode.
     : ∏ {x y : gquot G}, isweq (encode_gquot x y).
   Proof.
     intros x y.
-    use gradth.
+    use isweq_iso.
     - exact (decode_gquot x y).
     - intros z.
       apply decode_gquot_encode_gquot.


### PR DESCRIPTION
GrpdHITs should now work with Coq 8.18, and it can be added back to the CI.

Resolves https://github.com/UniMath/GrpdHITs/issues/22 and https://github.com/UniMath/UniMath/issues/1693